### PR TITLE
feature/responsive monthly/weekly leaderboard

### DIFF
--- a/src/components/LeaderboardTable.tsx
+++ b/src/components/LeaderboardTable.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
 import { KillLeaderboardEntry } from '../types';
 import { CareerIcon } from './CareerIcon';
+import './tableStyling.scss';
 
 export const LeaderboardTable = ({
   data,
@@ -31,7 +32,7 @@ export const LeaderboardTable = ({
             <tr key={leaderboardEntry.rank}>
               <td>{leaderboardEntry.rank}</td>
               <td>
-                <Media>
+                <Media className="leaderboard-player-data">
                   <Media.Item align="left">
                     <CareerIcon career={leaderboardEntry.character.career} />
                   </Media.Item>
@@ -51,12 +52,9 @@ export const LeaderboardTable = ({
                       </Link>
                     </Content>
                   </Media.Item>
-                  <Media.Item align="right">
-                    <small>
-                      Lvl {leaderboardEntry.character.level}
-                      <br />
-                      RR {leaderboardEntry.character.renownRank}
-                    </small>
+                  <Media.Item className="player-rr">
+                    <span>Lvl {leaderboardEntry.character.level}</span>
+                    <span>RR {leaderboardEntry.character.renownRank}</span>
                   </Media.Item>
                 </Media>
               </td>

--- a/src/components/tableStyling.scss
+++ b/src/components/tableStyling.scss
@@ -1,5 +1,9 @@
+@import '../../node_modules/bulma/sass/utilities/mixins.sass';
+
+$breakpoint-small: 475px;
+
 .leaderboard-player-data {
-  @media (max-width: 475px) {
+  @include until($breakpoint-small) {
     display: grid;
     grid-template-columns: 40px 1fr;
     grid-template-rows: 1fr;
@@ -7,7 +11,7 @@
 }
 
 .player-rr {
-  @media (max-width: 475px) {
+  @include until($breakpoint-small) {
     grid-template-columns: repeat(2, 1fr);
     grid-column-start: 2;
   }

--- a/src/components/tableStyling.scss
+++ b/src/components/tableStyling.scss
@@ -1,7 +1,7 @@
 .leaderboard-player-data {
   @media (max-width: 475px) {
     display: grid;
-    grid-template-columns: 0fr 1fr;
+    grid-template-columns: 40px 1fr;
     grid-template-rows: 1fr;
   }
 }

--- a/src/components/tableStyling.scss
+++ b/src/components/tableStyling.scss
@@ -1,0 +1,18 @@
+.leaderboard-player-data {
+  @media (max-width: 475px) {
+    display: grid;
+    grid-template-columns: 0fr 1fr;
+    grid-template-rows: 1fr;
+  }
+}
+
+.player-rr {
+  @media (max-width: 475px) {
+    grid-template-columns: repeat(2, 1fr);
+    grid-column-start: 2;
+  }
+  font-size: 13px;
+  display: grid;
+  grid-template-columns: 60px;
+  justify-content: end;
+}


### PR DESCRIPTION
Adds responsive layout to the Monthly and Weekly Leaderboards. Minor changes affect frontend as well; see before/after screenshots below for more info.

_Recent Kills has not been modified yet. It has a lot of info and needs extensive redesign to make it responsive._

Before (Desktop):
![image](https://user-images.githubusercontent.com/19802847/153902232-e78cfba3-1dca-46de-823b-50d502ee555c.png)


After (Desktop):
![image](https://user-images.githubusercontent.com/19802847/153902347-b5d69e98-7f25-45f4-9937-ebe53d684c62.png)



Before (Mobile):
![image](https://user-images.githubusercontent.com/19802847/153902492-2d985d96-7135-41f7-8839-ecdb0ac3f46a.png)



After (Mobile):
![image](https://user-images.githubusercontent.com/19802847/153904175-f261f665-5d22-4eb2-82f7-20a1a516c7e2.png)
