### PR TITLE
Add shared navigation and consistent Bulma styling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import './i18n/config';
 import React from 'react';
 import { Character } from '@/pages/Character';
 import { Home } from '@/pages/Home';
+import { MainNav } from '@/components/global/MainNav';
 import { Kill } from '@/pages/Kill';
 import { Guild } from '@/pages/Guild';
 import { Search } from '@/pages/Search';
@@ -54,103 +55,121 @@ const App = () => {
   usePageViews();
 
   return (
-    <Routes>
-      <Route path="/" element={<Home tab="players" />} />
-      <Route path="/guilds" element={<Home tab="guilds" />} />
-      <Route path="/scenarios" element={<Home tab="scenarios" />} />
-      <Route path="/kill/:id" element={<Kill />} />
-      <Route path="/kills" element={<Kills />} />
-      <Route path="/character/:id" element={<Character tab="kills" />} />
-      <Route
-        path="/character/:id/scenarios"
-        element={<Character tab="scenarios" />}
-      />
-      <Route
-        path="/character/:id/skirmishes"
-        element={<Character tab="skirmishes" />}
-      />
-      <Route
-        path="/character/:id/armory"
-        element={<Character tab="armory" />}
-      />
-      <Route
-        path="/character/:playerId1/feud/:playerId2"
-        element={<PlayerFeudPage />}
-      />
+    <>
+      <MainNav />
+      <Routes>
+        <Route path="/" element={<Home tab="players" />} />
+        <Route path="/guilds" element={<Home tab="guilds" />} />
+        <Route path="/scenarios" element={<Home tab="scenarios" />} />
+        <Route path="/kill/:id" element={<Kill />} />
+        <Route path="/kills" element={<Kills />} />
+        <Route path="/character/:id" element={<Character tab="kills" />} />
+        <Route
+          path="/character/:id/scenarios"
+          element={<Character tab="scenarios" />}
+        />
+        <Route
+          path="/character/:id/skirmishes"
+          element={<Character tab="skirmishes" />}
+        />
+        <Route
+          path="/character/:id/armory"
+          element={<Character tab="armory" />}
+        />
+        <Route
+          path="/character/:playerId1/feud/:playerId2"
+          element={<PlayerFeudPage />}
+        />
 
-      <Route path="/creatures" element={<Creatures />} />
-      <Route path="/creature/:id" element={<Creature />} />
-      <Route path="/creature/:id/quests" element={<Creature tab="quests" />} />
-      <Route
-        path="/creature/:id/vendorItems"
-        element={<Creature tab="vendorItems" />}
-      />
-      <Route path="/creature/:id/zone/:zoneId" element={<Creature />} />
+        <Route path="/creatures" element={<Creatures />} />
+        <Route path="/creature/:id" element={<Creature />} />
+        <Route
+          path="/creature/:id/quests"
+          element={<Creature tab="quests" />}
+        />
+        <Route
+          path="/creature/:id/vendorItems"
+          element={<Creature tab="vendorItems" />}
+        />
+        <Route path="/creature/:id/zone/:zoneId" element={<Creature />} />
 
-      <Route path="/gameobject/:id" element={<GameObject />} />
-      <Route path="/creature/:id/quests" element={<GameObject />} />
-      <Route path="/creature/:id/zone/:zoneId" element={<GameObject />} />
+        <Route path="/gameobject/:id" element={<GameObject />} />
+        <Route path="/creature/:id/quests" element={<GameObject />} />
+        <Route path="/creature/:id/zone/:zoneId" element={<GameObject />} />
 
-      <Route path="/guild/:id" element={<Guild tab="kills" />} />
-      <Route path="/guild/:id/members" element={<Guild tab="members" />} />
-      <Route path="/guild/:id/scenarios" element={<Guild tab="scenarios" />} />
-      <Route
-        path="/guild/:id/skirmishes"
-        element={<Guild tab="skirmishes" />}
-      />
-      <Route
-        path="/guild/:guildId1/feud/:guildId2"
-        element={<GuildFeudPage />}
-      />
+        <Route path="/guild/:id" element={<Guild tab="kills" />} />
+        <Route path="/guild/:id/members" element={<Guild tab="members" />} />
+        <Route
+          path="/guild/:id/scenarios"
+          element={<Guild tab="scenarios" />}
+        />
+        <Route
+          path="/guild/:id/skirmishes"
+          element={<Guild tab="skirmishes" />}
+        />
+        <Route
+          path="/guild/:guildId1/feud/:guildId2"
+          element={<GuildFeudPage />}
+        />
 
-      <Route path="/quests" element={<Quests />} />
-      <Route path="/quest/:id" element={<Quest />} />
+        <Route path="/quests" element={<Quests />} />
+        <Route path="/quest/:id" element={<Quest />} />
 
-      <Route path="/search/:query" element={<Search />} />
-      <Route path="/search/guild/:query" element={<SearchGuild />} />
+        <Route path="/search/:query" element={<Search />} />
+        <Route path="/search/guild/:query" element={<SearchGuild />} />
 
-      <Route path="/scenario/:id" element={<Scenario tab="scoreboard" />} />
-      <Route path="/scenario/:id/kills" element={<Scenario tab="kills" />} />
-      <Route
-        path="/scenario/:id/skirmishes"
-        element={<Scenario tab="skirmishes" />}
-      />
-      <Route path="/scenario/:id/map" element={<Scenario tab="map" />} />
-      <Route path="/skirmishes" element={<Home tab="skirmishes" />} />
-      <Route path="/skirmish/:id" element={<Skirmish tab="scoreboard" />} />
-      <Route path="/skirmish/:id/kills" element={<Skirmish tab="kills" />} />
-      <Route
-        path="/skirmish/:id/damage/:characterId"
-        element={<Skirmish tab="characterDamage" />}
-      />
-      <Route path="/skirmish/:id/damage" element={<Skirmish tab="damage" />} />
-      <Route path="/zone_heatmap/:id" element={<ZoneMap />} />
+        <Route path="/scenario/:id" element={<Scenario tab="scoreboard" />} />
+        <Route path="/scenario/:id/kills" element={<Scenario tab="kills" />} />
+        <Route
+          path="/scenario/:id/skirmishes"
+          element={<Scenario tab="skirmishes" />}
+        />
+        <Route path="/scenario/:id/map" element={<Scenario tab="map" />} />
+        <Route path="/skirmishes" element={<Home tab="skirmishes" />} />
+        <Route path="/skirmish/:id" element={<Skirmish tab="scoreboard" />} />
+        <Route path="/skirmish/:id/kills" element={<Skirmish tab="kills" />} />
+        <Route
+          path="/skirmish/:id/damage/:characterId"
+          element={<Skirmish tab="characterDamage" />}
+        />
+        <Route
+          path="/skirmish/:id/damage"
+          element={<Skirmish tab="damage" />}
+        />
+        <Route path="/zone_heatmap/:id" element={<ZoneMap />} />
 
-      <Route path="/items" element={<Items />} />
-      <Route path="/item/:id" element={<Item tab="vendors" />} />
-      <Route path="/item/:id/purchase" element={<Item tab="purchase" />} />
-      <Route path="/item/:id/quests" element={<Item tab="quests" />} />
+        <Route path="/items" element={<Items />} />
+        <Route path="/item/:id" element={<Item tab="vendors" />} />
+        <Route path="/item/:id/purchase" element={<Item tab="purchase" />} />
+        <Route path="/item/:id/quests" element={<Item tab="quests" />} />
 
-      <Route path="/instance-runs" element={<InstanceRuns />} />
-      <Route path="/instance-run/:id" element={<InstanceRun />} />
-      <Route
-        path="/instance-run/:instanceRunId/:id"
-        element={<InstanceEncounterRun />}
-      />
+        <Route path="/instance-runs" element={<InstanceRuns />} />
+        <Route path="/instance-run/:id" element={<InstanceRun />} />
+        <Route
+          path="/instance-run/:instanceRunId/:id"
+          element={<InstanceEncounterRun />}
+        />
 
-      <Route path="/instances" element={<Instances />} />
-      <Route path="/instance-statistics/:id" element={<InstanceStatistics />} />
+        <Route path="/instances" element={<Instances />} />
+        <Route
+          path="/instance-statistics/:id"
+          element={<InstanceStatistics />}
+        />
 
-      <Route path="/storylines" element={<Storylines />} />
-      <Route path="/storylines/:id" element={<Storyline />} />
-      <Route path="/storylines/:storylineId/:id" element={<StorylineEntry />} />
-      <Route
-        path="/storylines/:storylineId/:storylineEntryId/:id"
-        element={<StorylineActivity />}
-      />
+        <Route path="/storylines" element={<Storylines />} />
+        <Route path="/storylines/:id" element={<Storyline />} />
+        <Route
+          path="/storylines/:storylineId/:id"
+          element={<StorylineEntry />}
+        />
+        <Route
+          path="/storylines/:storylineId/:storylineEntryId/:id"
+          element={<StorylineActivity />}
+        />
 
-      <Route path="/ranked-leaderboard" element={<RankedLeaderboard />} />
-    </Routes>
+        <Route path="/ranked-leaderboard" element={<RankedLeaderboard />} />
+      </Routes>
+    </>
   );
 };
 

--- a/src/components/global/MainNav.tsx
+++ b/src/components/global/MainNav.tsx
@@ -1,0 +1,49 @@
+import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
+import { Link, useLocation } from 'react-router';
+import type { ReactElement } from 'react';
+
+// Persistent top nav, rendered on every page (see App.tsx). Nav links are
+// alphabetical by label. Items, Quests, Creatures, Instances, and
+// Storylines each have their own route and full page layout; the
+// ranked leaderboard page intentionally isn't added here.
+export const MainNav = (): ReactElement => {
+  const { t } = useTranslation();
+  const { pathname } = useLocation();
+
+  return (
+    <div className="container is-max-widescreen mt-2">
+      <div className="tabs is-fullwidth">
+        <li className={clsx({ 'is-active': pathname.startsWith('/creature') })}>
+          <Link to="/creatures">{t('pages:home.showCreatures')}</Link>
+        </li>
+        <li className={clsx({ 'is-active': pathname === '/guilds' })}>
+          <Link to="/guilds">{t('pages:home.showGuildLeaderboard')}</Link>
+        </li>
+        <li className={clsx({ 'is-active': pathname.startsWith('/instance') })}>
+          <Link to="/instances">{t('pages:home.showInstances')}</Link>
+        </li>
+        <li className={clsx({ 'is-active': pathname.startsWith('/item') })}>
+          <Link to="/items">{t('pages:home.showItems')}</Link>
+        </li>
+        <li className={clsx({ 'is-active': pathname === '/' })}>
+          <Link to="/">{t('pages:home.showPlayerLeaderboard')}</Link>
+        </li>
+        <li className={clsx({ 'is-active': pathname.startsWith('/quest') })}>
+          <Link to="/quests">{t('pages:home.showQuests')}</Link>
+        </li>
+        <li className={clsx({ 'is-active': pathname === '/scenarios' })}>
+          <Link to="/scenarios">{t('pages:home.showScenarios')}</Link>
+        </li>
+        <li className={clsx({ 'is-active': pathname === '/skirmishes' })}>
+          <Link to="/skirmishes">{t('pages:home.showSkirmishes')}</Link>
+        </li>
+        <li
+          className={clsx({ 'is-active': pathname.startsWith('/storylines') })}
+        >
+          <Link to="/storylines">{t('pages:home.showStorylines')}</Link>
+        </li>
+      </div>
+    </div>
+  );
+};

--- a/src/components/item/ItemVendorsFilters.tsx
+++ b/src/components/item/ItemVendorsFilters.tsx
@@ -26,101 +26,95 @@ export const ItemVendorsFilters = (): ReactElement => {
   const career = search.get('career') || 'all';
 
   return (
-    <div className="card mb-5">
-      <div className="card-content">
-        <div className="columns">
-          <div className="column">
-            <div className="field">
-              <label className="label">
-                {t('components:itemVendorsFilters.career')}
-              </label>
-              <select
-                value={career}
-                onChange={(event) => {
-                  search.set('career', event.target.value);
-                  setSearch(search);
-                }}
-              >
-                <option value="all">
-                  {t('components:itemVendorsFilters.all')}
-                </option>
-                <option value={Career.IronBreaker}>
-                  {t(`enums:career.${Career.IronBreaker}`)}
-                </option>
-                <option value={Career.Slayer}>
-                  {t(`enums:career.${Career.Slayer}`)}
-                </option>
-                <option value={Career.RunePriest}>
-                  {t(`enums:career.${Career.RunePriest}`)}
-                </option>
-                <option value={Career.Engineer}>
-                  {t(`enums:career.${Career.Engineer}`)}
-                </option>
-                <option value={Career.BlackOrc}>
-                  {t(`enums:career.${Career.BlackOrc}`)}
-                </option>
-                <option value={Career.Choppa}>
-                  {t(`enums:career.${Career.Choppa}`)}
-                </option>
-                <option value={Career.Shaman}>
-                  {t(`enums:career.${Career.Shaman}`)}
-                </option>
-                <option value={Career.SquigHerder}>
-                  {t(`enums:career.${Career.SquigHerder}`)}
-                </option>
-                <option value={Career.WitchHunter}>
-                  {t(`enums:career.${Career.WitchHunter}`)}
-                </option>
-                <option value={Career.KnightOfTheBlazingSun}>
-                  {t(`enums:career.${Career.KnightOfTheBlazingSun}`)}
-                </option>
-                <option value={Career.BrightWizard}>
-                  {t(`enums:career.${Career.BrightWizard}`)}
-                </option>
-                <option value={Career.WarriorPriest}>
-                  {t(`enums:career.${Career.WarriorPriest}`)}
-                </option>
-                <option value={Career.Chosen}>
-                  {t(`enums:career.${Career.Chosen}`)}
-                </option>
-                <option value={Career.Marauder}>
-                  {t(`enums:career.${Career.Marauder}`)}
-                </option>
-                <option value={Career.Zealot}>
-                  {t(`enums:career.${Career.Zealot}`)}
-                </option>
-                <option value={Career.Magus}>
-                  {t(`enums:career.${Career.Magus}`)}
-                </option>
-                <option value={Career.SwordMaster}>
-                  {t(`enums:career.${Career.SwordMaster}`)}
-                </option>
-                <option value={Career.ShadowWarrior}>
-                  {t(`enums:career.${Career.ShadowWarrior}`)}
-                </option>
-                <option value={Career.WhiteLion}>
-                  {t(`enums:career.${Career.WhiteLion}`)}
-                </option>
-                <option value={Career.Archmage}>
-                  {t(`enums:career.${Career.Archmage}`)}
-                </option>
-                <option value={Career.BlackGuard}>
-                  {t(`enums:career.${Career.BlackGuard}`)}
-                </option>
-                <option value={Career.WitchElf}>
-                  {t(`enums:career.${Career.WitchElf}`)}
-                </option>
-                <option value={Career.DiscipleOfKhaine}>
-                  {t(`enums:career.${Career.DiscipleOfKhaine}`)}
-                </option>
-                <option value={Career.Sorcerer}>
-                  {t(`enums:career.${Career.Sorcerer}`)}
-                </option>
-              </select>
-            </div>
-          </div>
+    <div className="filter-grid">
+      <label>
+        <span>{t('components:itemVendorsFilters.career')}</span>
+        <div className="select">
+          <select
+            value={career}
+            onChange={(event) => {
+              search.set('career', event.target.value);
+              setSearch(search);
+            }}
+          >
+            <option value="all">
+              {t('components:itemVendorsFilters.all')}
+            </option>
+            <option value={Career.IronBreaker}>
+              {t(`enums:career.${Career.IronBreaker}`)}
+            </option>
+            <option value={Career.Slayer}>
+              {t(`enums:career.${Career.Slayer}`)}
+            </option>
+            <option value={Career.RunePriest}>
+              {t(`enums:career.${Career.RunePriest}`)}
+            </option>
+            <option value={Career.Engineer}>
+              {t(`enums:career.${Career.Engineer}`)}
+            </option>
+            <option value={Career.BlackOrc}>
+              {t(`enums:career.${Career.BlackOrc}`)}
+            </option>
+            <option value={Career.Choppa}>
+              {t(`enums:career.${Career.Choppa}`)}
+            </option>
+            <option value={Career.Shaman}>
+              {t(`enums:career.${Career.Shaman}`)}
+            </option>
+            <option value={Career.SquigHerder}>
+              {t(`enums:career.${Career.SquigHerder}`)}
+            </option>
+            <option value={Career.WitchHunter}>
+              {t(`enums:career.${Career.WitchHunter}`)}
+            </option>
+            <option value={Career.KnightOfTheBlazingSun}>
+              {t(`enums:career.${Career.KnightOfTheBlazingSun}`)}
+            </option>
+            <option value={Career.BrightWizard}>
+              {t(`enums:career.${Career.BrightWizard}`)}
+            </option>
+            <option value={Career.WarriorPriest}>
+              {t(`enums:career.${Career.WarriorPriest}`)}
+            </option>
+            <option value={Career.Chosen}>
+              {t(`enums:career.${Career.Chosen}`)}
+            </option>
+            <option value={Career.Marauder}>
+              {t(`enums:career.${Career.Marauder}`)}
+            </option>
+            <option value={Career.Zealot}>
+              {t(`enums:career.${Career.Zealot}`)}
+            </option>
+            <option value={Career.Magus}>
+              {t(`enums:career.${Career.Magus}`)}
+            </option>
+            <option value={Career.SwordMaster}>
+              {t(`enums:career.${Career.SwordMaster}`)}
+            </option>
+            <option value={Career.ShadowWarrior}>
+              {t(`enums:career.${Career.ShadowWarrior}`)}
+            </option>
+            <option value={Career.WhiteLion}>
+              {t(`enums:career.${Career.WhiteLion}`)}
+            </option>
+            <option value={Career.Archmage}>
+              {t(`enums:career.${Career.Archmage}`)}
+            </option>
+            <option value={Career.BlackGuard}>
+              {t(`enums:career.${Career.BlackGuard}`)}
+            </option>
+            <option value={Career.WitchElf}>
+              {t(`enums:career.${Career.WitchElf}`)}
+            </option>
+            <option value={Career.DiscipleOfKhaine}>
+              {t(`enums:career.${Career.DiscipleOfKhaine}`)}
+            </option>
+            <option value={Career.Sorcerer}>
+              {t(`enums:career.${Career.Sorcerer}`)}
+            </option>
+          </select>
         </div>
-      </div>
+      </label>
     </div>
   );
 };

--- a/src/components/skirmish/SkirmishFilters.tsx
+++ b/src/components/skirmish/SkirmishFilters.tsx
@@ -69,58 +69,44 @@ export const SkirmishFilters = (): ReactElement => {
   const locationType = search.get('type') || 'all';
 
   return (
-    <div className="card mb-5">
-      <div className="card-content">
-        <div className="columns">
-          <div className="column">
-            <div className="field">
-              <label className="label">
-                {t('skirmishFilters.locationType')}
-              </label>
-              <select
-                value={locationType}
-                onChange={(event) => {
-                  search.set('type', event.target.value);
-                  setSearch(search);
-                }}
-              >
-                <option value="all">
-                  {t('skirmishFilters.locationTypeAll')}
-                </option>
-                <option value="rvr">
-                  {t('skirmishFilters.locationTypeRvr')}
-                </option>
-                <option value="rvrt1">
-                  {t('skirmishFilters.locationTypeRvrT1')}
-                </option>
-                <option value="scenario">
-                  {t('skirmishFilters.locationTypeScenario')}
-                </option>
-              </select>
-            </div>
-          </div>
-          <div className="column">
-            <div className="field">
-              <label className="label">{t('skirmishFilters.minPlayers')}</label>
-              <select
-                onChange={(event) => {
-                  search.set('minPlayers', event.target.value);
-                  setSearch(search);
-                }}
-              >
-                <option value="all">
-                  {t('skirmishFilters.minPlayersAll')}
-                </option>
-                <option value="12">{t('skirmishFilters.minPlayers12')}</option>
-                <option value="48">{t('skirmishFilters.minPlayers48')}</option>
-                <option value="100">
-                  {t('skirmishFilters.minPlayers100')}
-                </option>
-              </select>
-            </div>
-          </div>
+    <div className="filter-grid">
+      <label>
+        <span>{t('skirmishFilters.locationType')}</span>
+        <div className="select">
+          <select
+            value={locationType}
+            onChange={(event) => {
+              search.set('type', event.target.value);
+              setSearch(search);
+            }}
+          >
+            <option value="all">{t('skirmishFilters.locationTypeAll')}</option>
+            <option value="rvr">{t('skirmishFilters.locationTypeRvr')}</option>
+            <option value="rvrt1">
+              {t('skirmishFilters.locationTypeRvrT1')}
+            </option>
+            <option value="scenario">
+              {t('skirmishFilters.locationTypeScenario')}
+            </option>
+          </select>
         </div>
-      </div>
+      </label>
+      <label>
+        <span>{t('skirmishFilters.minPlayers')}</span>
+        <div className="select">
+          <select
+            onChange={(event) => {
+              search.set('minPlayers', event.target.value);
+              setSearch(search);
+            }}
+          >
+            <option value="all">{t('skirmishFilters.minPlayersAll')}</option>
+            <option value="12">{t('skirmishFilters.minPlayers12')}</option>
+            <option value="48">{t('skirmishFilters.minPlayers48')}</option>
+            <option value="100">{t('skirmishFilters.minPlayers100')}</option>
+          </select>
+        </div>
+      </label>
     </div>
   );
 };

--- a/src/i18n/en/pages.json
+++ b/src/i18n/en/pages.json
@@ -28,7 +28,12 @@
     "showGuildLeaderboard": "Guilds",
     "showPlayerLeaderboard": "Players",
     "showScenarios": "Scenarios",
-    "showSkirmishes": "Skirmishes"
+    "showSkirmishes": "Skirmishes",
+    "showItems": "Items",
+    "showQuests": "Quests",
+    "showCreatures": "Creatures",
+    "showInstances": "Instances",
+    "showStorylines": "Storylines"
   },
   "killPage": {
     "killer": "Killer",

--- a/src/pages/Creatures.tsx
+++ b/src/pages/Creatures.tsx
@@ -95,19 +95,17 @@ export const Creatures = (): ReactElement => {
         </ul>
       </nav>
 
-      <div className="card mb-5">
-        <div className="card-content">
-          <div className="field">
-            <label className="label">{t('pages:creatures.search')}</label>
-            <SearchBox
-              initialQuery={search.get('name') || ''}
-              onSubmit={(event) => {
-                search.set('name', event);
-                setSearch(search);
-              }}
-            />
-          </div>
-        </div>
+      <div className="filter-grid">
+        <label>
+          <span>{t('pages:creatures.search')}</span>
+          <SearchBox
+            initialQuery={search.get('name') || ''}
+            onSubmit={(event) => {
+              search.set('name', event);
+              setSearch(search);
+            }}
+          />
+        </label>
       </div>
 
       <div className="table-container">

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,3 @@
-import clsx from 'clsx';
-import { useTranslation } from 'react-i18next';
-import { Link } from 'react-router';
 import { LatestKills } from '@/components/kill/LatestKills';
 import { WeeklyLeaderboard } from '@/components/kill/WeeklyLeaderboard';
 import { SearchBox } from '@/components/global/SearchBox';
@@ -18,24 +15,8 @@ export const Home = ({
 }: {
   tab: 'players' | 'guilds' | 'scenarios' | 'skirmishes';
 }): ReactElement => {
-  const { t } = useTranslation();
-
   return (
-    <div className="container is-mobile mt-2">
-      <div className="tabs is-fullwidth">
-        <li className={clsx({ 'is-active': tab === 'players' })}>
-          <Link to="/">{t('pages:home.showPlayerLeaderboard')}</Link>
-        </li>
-        <li className={clsx({ 'is-active': tab === 'guilds' })}>
-          <Link to="/guilds">{t('pages:home.showGuildLeaderboard')}</Link>
-        </li>
-        <li className={clsx({ 'is-active': tab === 'scenarios' })}>
-          <Link to="/scenarios">{t('pages:home.showScenarios')}</Link>
-        </li>
-        <li className={clsx({ 'is-active': tab === 'skirmishes' })}>
-          <Link to="/skirmishes">{t('pages:home.showSkirmishes')}</Link>
-        </li>
-      </div>
+    <div className="container is-max-widescreen mt-2">
       {tab === 'scenarios' && (
         <>
           <ScenarioFilters />

--- a/src/pages/Instances.tsx
+++ b/src/pages/Instances.tsx
@@ -95,24 +95,22 @@ export const Instances = (): ReactElement => {
             <Link to="/">{t('common:home')}</Link>
           </li>
           <li className="is-active">
-            <Link to="/creatures">{t('pages:creatures.title')}</Link>
+            <Link to="/instances">{t('pages:instances.title')}</Link>
           </li>
         </ul>
       </nav>
 
-      <div className="card mb-5">
-        <div className="card-content">
-          <div className="field">
-            <label className="label">{t('pages:instances.search')}</label>
-            <SearchBox
-              initialQuery={search.get('name') || ''}
-              onSubmit={(event) => {
-                search.set('name', event);
-                setSearch(search);
-              }}
-            />
-          </div>
-        </div>
+      <div className="filter-grid">
+        <label>
+          <span>{t('pages:instances.search')}</span>
+          <SearchBox
+            initialQuery={search.get('name') || ''}
+            onSubmit={(event) => {
+              search.set('name', event);
+              setSearch(search);
+            }}
+          />
+        </label>
       </div>
 
       <div className="table-container">

--- a/src/pages/Item.tsx
+++ b/src/pages/Item.tsx
@@ -121,7 +121,7 @@ export const Item = ({
   const activeTab = activeTabs.includes(tab) ? tab : activeTabs[0];
 
   return (
-    <div className="container is-widescreen mt-2">
+    <div className="container is-max-widescreen mt-2">
       <nav className="breadcrumb" aria-label="breadcrumbs">
         <ul>
           <li>

--- a/src/pages/Items.tsx
+++ b/src/pages/Items.tsx
@@ -127,7 +127,7 @@ export const Items = (): ReactElement => {
   const { pageInfo } = data.items;
 
   return (
-    <div className="container is-max-desktop mt-2">
+    <div className="container is-max-widescreen mt-2">
       <nav className="breadcrumb" aria-label="breadcrumbs">
         <ul>
           <li>
@@ -138,301 +138,261 @@ export const Items = (): ReactElement => {
           </li>
         </ul>
       </nav>
-      <div className="card mb-5">
-        <div className="card-content">
-          <div className="field">
-            <label className="label">{t('pages:items.search')}</label>
-            <SearchBox
-              initialQuery={search.get('query') || ''}
-              onSubmit={(event) => {
-                search.set('query', event);
+      <div className="filter-grid">
+        <label>
+          <span>{t('pages:items.search')}</span>
+          <SearchBox
+            initialQuery={search.get('query') || ''}
+            onSubmit={(event) => {
+              search.set('query', event);
+              setSearch(search);
+            }}
+          />
+        </label>
+        <label htmlFor="type">
+          <span>{t('pages:items.itemType')}</span>
+          <div className="select">
+            <select
+              id="type"
+              value={search.get('type') ?? undefined}
+              onChange={(event) => {
+                search.set('type', event.target.value);
                 setSearch(search);
               }}
-            />
+            >
+              <option value="all">{t('pages:items.all')}</option>
+              <option value="SWORD">{t('enums:itemType.SWORD')}</option>
+              <option value="AXE">{t('enums:itemType.AXE')}</option>
+              <option value="HAMMER">{t('enums:itemType.HAMMER')}</option>
+              <option value="BASIC_SHIELD">
+                {t('enums:itemType.BASIC_SHIELD')}
+              </option>
+              <option value="SHIELD">{t('enums:itemType.SHIELD')}</option>
+              <option value="ROBE">{t('enums:itemType.ROBE')}</option>
+              <option value="BOW">{t('enums:itemType.BOW')}</option>
+              <option value="CROSSBOW">{t('enums:itemType.CROSSBOW')}</option>
+              <option value="GUN">{t('enums:itemType.GUN')}</option>
+              <option value="EXPERT_SHIELD">
+                {t('enums:itemType.EXPERT_SHIELD')}
+              </option>
+              <option value="STAFF">{t('enums:itemType.STAFF')}</option>
+              <option value="DAGGER">{t('enums:itemType.DAGGER')}</option>
+              <option value="SPEAR">{t('enums:itemType.SPEAR')}</option>
+              <option value="PISTOL">{t('enums:itemType.PISTOL')}</option>
+              <option value="LANCE">{t('enums:itemType.LANCE')}</option>
+              <option value="REPEATING_CROSSBOW">
+                {t('enums:itemType.REPEATING_CROSSBOW')}
+              </option>
+              <option value="LIGHT_ARMOR">
+                {t('enums:itemType.LIGHT_ARMOR')}
+              </option>
+              <option value="MEDIUM_ARMOR">
+                {t('enums:itemType.MEDIUM_ARMOR')}
+              </option>
+              <option value="HEAVY_ARMOR">
+                {t('enums:itemType.HEAVY_ARMOR')}
+              </option>
+              <option value="QUEST">{t('enums:itemType.QUEST')}</option>
+              <option value="MEDIUM_ROBE">
+                {t('enums:itemType.MEDIUM_ROBE')}
+              </option>
+              <option value="ENHANCEMENT">
+                {t('enums:itemType.ENHANCEMENT')}
+              </option>
+              <option value="TROPHY">{t('enums:itemType.TROPHY')}</option>
+              <option value="CHARM">{t('enums:itemType.CHARM')}</option>
+              <option value="DYE">{t('enums:itemType.DYE')}</option>
+              <option value="BASIC_MOUNT">
+                {t('enums:itemType.BASIC_MOUNT')}
+              </option>
+              <option value="ADVANCED_MOUNT">
+                {t('enums:itemType.ADVANCED_MOUNT')}
+              </option>
+              <option value="POTION">{t('enums:itemType.POTION')}</option>
+              <option value="SALVAGING">{t('enums:itemType.SALVAGING')}</option>
+              <option value="MARKETING">{t('enums:itemType.MARKETING')}</option>
+              <option value="CRAFTING">{t('enums:itemType.CRAFTING')}</option>
+              <option value="ACCESSORY">{t('enums:itemType.ACCESSORY')}</option>
+              <option value="CURRENCY">{t('enums:itemType.CURRENCY')}</option>
+              <option value="TELEPORT">{t('enums:itemType.TELEPORT')}</option>
+              <option value="TELEPORT_GROUP">
+                {t('enums:itemType.TELEPORT_GROUP')}
+              </option>
+              <option value="SIEGE">{t('enums:itemType.SIEGE')}</option>
+              <option value="TREASURE_CHEST">
+                {t('enums:itemType.TREASURE_CHEST')}
+              </option>
+              <option value="TREASURE_KEY">
+                {t('enums:itemType.TREASURE_KEY')}
+              </option>
+              <option value="REFINER_TOOL">
+                {t('enums:itemType.REFINER_TOOL')}
+              </option>
+            </select>
           </div>
-          <div className="columns">
-            <div className="column">
-              <div className="field">
-                <label className="label" htmlFor="type">
-                  {t('pages:items.itemType')}
-                </label>
-                <select
-                  id="type"
-                  value={search.get('type') ?? undefined}
-                  onChange={(event) => {
-                    search.set('type', event.target.value);
-                    setSearch(search);
-                  }}
-                >
-                  <option value="all">{t('pages:items.all')}</option>
-                  <option value="SWORD">{t('enums:itemType.SWORD')}</option>
-                  <option value="AXE">{t('enums:itemType.AXE')}</option>
-                  <option value="HAMMER">{t('enums:itemType.HAMMER')}</option>
-                  <option value="BASIC_SHIELD">
-                    {t('enums:itemType.BASIC_SHIELD')}
-                  </option>
-                  <option value="SHIELD">{t('enums:itemType.SHIELD')}</option>
-                  <option value="ROBE">{t('enums:itemType.ROBE')}</option>
-                  <option value="BOW">{t('enums:itemType.BOW')}</option>
-                  <option value="CROSSBOW">
-                    {t('enums:itemType.CROSSBOW')}
-                  </option>
-                  <option value="GUN">{t('enums:itemType.GUN')}</option>
-                  <option value="EXPERT_SHIELD">
-                    {t('enums:itemType.EXPERT_SHIELD')}
-                  </option>
-                  <option value="STAFF">{t('enums:itemType.STAFF')}</option>
-                  <option value="DAGGER">{t('enums:itemType.DAGGER')}</option>
-                  <option value="SPEAR">{t('enums:itemType.SPEAR')}</option>
-                  <option value="PISTOL">{t('enums:itemType.PISTOL')}</option>
-                  <option value="LANCE">{t('enums:itemType.LANCE')}</option>
-                  <option value="REPEATING_CROSSBOW">
-                    {t('enums:itemType.REPEATING_CROSSBOW')}
-                  </option>
-                  <option value="LIGHT_ARMOR">
-                    {t('enums:itemType.LIGHT_ARMOR')}
-                  </option>
-                  <option value="MEDIUM_ARMOR">
-                    {t('enums:itemType.MEDIUM_ARMOR')}
-                  </option>
-                  <option value="HEAVY_ARMOR">
-                    {t('enums:itemType.HEAVY_ARMOR')}
-                  </option>
-                  <option value="QUEST">{t('enums:itemType.QUEST')}</option>
-                  <option value="MEDIUM_ROBE">
-                    {t('enums:itemType.MEDIUM_ROBE')}
-                  </option>
-                  <option value="ENHANCEMENT">
-                    {t('enums:itemType.ENHANCEMENT')}
-                  </option>
-                  <option value="TROPHY">{t('enums:itemType.TROPHY')}</option>
-                  <option value="CHARM">{t('enums:itemType.CHARM')}</option>
-                  <option value="DYE">{t('enums:itemType.DYE')}</option>
-                  <option value="BASIC_MOUNT">
-                    {t('enums:itemType.BASIC_MOUNT')}
-                  </option>
-                  <option value="ADVANCED_MOUNT">
-                    {t('enums:itemType.ADVANCED_MOUNT')}
-                  </option>
-                  <option value="POTION">{t('enums:itemType.POTION')}</option>
-                  <option value="SALVAGING">
-                    {t('enums:itemType.SALVAGING')}
-                  </option>
-                  <option value="MARKETING">
-                    {t('enums:itemType.MARKETING')}
-                  </option>
-                  <option value="CRAFTING">
-                    {t('enums:itemType.CRAFTING')}
-                  </option>
-                  <option value="ACCESSORY">
-                    {t('enums:itemType.ACCESSORY')}
-                  </option>
-                  <option value="CURRENCY">
-                    {t('enums:itemType.CURRENCY')}
-                  </option>
-                  <option value="TELEPORT">
-                    {t('enums:itemType.TELEPORT')}
-                  </option>
-                  <option value="TELEPORT_GROUP">
-                    {t('enums:itemType.TELEPORT_GROUP')}
-                  </option>
-                  <option value="SIEGE">{t('enums:itemType.SIEGE')}</option>
-                  <option value="TREASURE_CHEST">
-                    {t('enums:itemType.TREASURE_CHEST')}
-                  </option>
-                  <option value="TREASURE_KEY">
-                    {t('enums:itemType.TREASURE_KEY')}
-                  </option>
-                  <option value="REFINER_TOOL">
-                    {t('enums:itemType.REFINER_TOOL')}
-                  </option>
-                </select>
-              </div>
-            </div>
-            <div className="column">
-              <div className="field">
-                <label className="label" htmlFor="stat">
-                  {t('pages:items.stat')}
-                </label>
-                <select
-                  id="stat"
-                  value={search.get('stat') ?? undefined}
-                  onChange={(event) => {
-                    search.set('stat', event.target.value);
-                    setSearch(search);
-                  }}
-                >
-                  <option value="any">{t('pages:items.any')}</option>
-                  <option value="WOUNDS">{t('enums:stat.WOUNDS')}</option>
-                  <option value="WEAPON_SKILL">
-                    {t('enums:stat.WEAPON_SKILL')}
-                  </option>
-                  <option value="WILLPOWER">{t('enums:stat.WILLPOWER')}</option>
-                  <option value="BALLISTIC_SKILL">
-                    {t('enums:stat.BALLISTIC_SKILL')}
-                  </option>
-                  <option value="TOUGHNESS">{t('enums:stat.TOUGHNESS')}</option>
-                  <option value="INITIATIVE">
-                    {t('enums:stat.INITIATIVE')}
-                  </option>
-                  <option value="STRENGTH">{t('enums:stat.STRENGTH')}</option>
-                  <option value="INTELLIGENCE">
-                    {t('enums:stat.INTELLIGENCE')}
-                  </option>
-                  <option value="BLOCK">{t('enums:stat.BLOCK')}</option>
-                  <option value="PARRY">{t('enums:stat.PARRY')}</option>
-                  <option value="DISRUPT">{t('enums:stat.DISRUPT')}</option>
-                  <option value="EVADE">{t('enums:stat.EVADE')}</option>
-                  <option value="ELEMENTAL_RESISTANCE">
-                    {t('enums:stat.ELEMENTAL_RESISTANCE')}
-                  </option>
-                  <option value="SPIRIT_RESISTANCE">
-                    {t('enums:stat.SPIRIT_RESISTANCE')}
-                  </option>
-                  <option value="CORPOREAL_RESISTANCE">
-                    {t('enums:stat.CORPOREAL_RESISTANCE')}
-                  </option>
-                  <option value="HEAL_CRIT_RATE">
-                    {t('enums:stat.HEAL_CRIT_RATE')}
-                  </option>
-                  <option value="RANGED_CRIT_RATE">
-                    {t('enums:stat.RANGED_CRIT_RATE')}
-                  </option>
-                  <option value="MELEE_CRIT_RATE">
-                    {t('enums:stat.MELEE_CRIT_RATE')}
-                  </option>
-                  <option value="MAGIC_CRIT_RATE">
-                    {t('enums:stat.MAGIC_CRIT_RATE')}
-                  </option>
-                  <option value="ACTION_POINT_REGEN">
-                    {t('enums:stat.ACTION_POINT_REGEN')}
-                  </option>
-                  <option value="MORALE_REGEN">
-                    {t('enums:stat.MORALE_REGEN')}
-                  </option>
-                  <option value="HEALTH_REGEN">
-                    {t('enums:stat.HEALTH_REGEN')}
-                  </option>
-                  <option value="CRITICAL_HIT_RATE_REDUCTION">
-                    {t('enums:stat.CRITICAL_HIT_RATE_REDUCTION')}
-                  </option>
-                  <option value="BLOCK_STRIKETHROUGH">
-                    {t('enums:stat.BLOCK_STRIKETHROUGH')}
-                  </option>
-                  <option value="PARRY_STRIKETHROUGH">
-                    {t('enums:stat.PARRY_STRIKETHROUGH')}
-                  </option>
-                  <option value="DISRUPT_STRIKETHROUGH">
-                    {t('enums:stat.DISRUPT_STRIKETHROUGH')}
-                  </option>
-                  <option value="EVADE_STRIKETHROUGH">
-                    {t('enums:stat.EVADE_STRIKETHROUGH')}
-                  </option>
-                  <option value="HEALING_POWER">
-                    {t('enums:stat.HEALING_POWER')}
-                  </option>
-                  <option value="MAGIC_POWER">
-                    {t('enums:stat.MAGIC_POWER')}
-                  </option>
-                  <option value="RANGED_POWER">
-                    {t('enums:stat.RANGED_POWER')}
-                  </option>
-                  <option value="MELEE_POWER">
-                    {t('enums:stat.MELEE_POWER')}
-                  </option>
-                  <option value="FORTITUDE">{t('enums:stat.FORTITUDE')}</option>
-                  <option value="AUTO_ATTACK_SPEED">
-                    {t('enums:stat.AUTO_ATTACK_SPEED')}
-                  </option>
-                  <option value="AUTO_ATTACK_DAMAGE">
-                    {t('enums:stat.AUTO_ATTACK_DAMAGE')}
-                  </option>
-                  <option value="ARMOR_PENETRATION">
-                    {t('enums:stat.ARMOR_PENETRATION')}
-                  </option>
-                  <option value="ARMOR_PENETRATION_REDUCTION">
-                    {t('enums:stat.ARMOR_PENETRATION_REDUCTION')}
-                  </option>
-                  <option value="HATE_CAUSED">
-                    {t('enums:stat.HATE_CAUSED')}
-                  </option>
-                  <option value="HATE_RECEIVED">
-                    {t('enums:stat.HATE_RECEIVED')}
-                  </option>
-                </select>
-              </div>
-            </div>
-            <div className="column">
-              <div className="field">
-                <label className="label" htmlFor="career">
-                  {t('pages:items.usableByCareer')}
-                </label>
-                <select
-                  id="career"
-                  value={search.get('career') ?? undefined}
-                  onChange={(event) => {
-                    search.set('career', event.target.value);
-                    setSearch(search);
-                  }}
-                >
-                  <option value="all">{t('pages:items.all')}</option>
-                  <option value="ARCHMAGE">{t('enums:career.ARCHMAGE')}</option>
-                  <option value="BLACKGUARD">
-                    {t('enums:career.BLACKGUARD')}
-                  </option>
-                  <option value="BLACK_ORC">
-                    {t('enums:career.BLACK_ORC')}
-                  </option>
-                  <option value="BRIGHT_WIZARD">
-                    {t('enums:career.BRIGHT_WIZARD')}
-                  </option>
-                  <option value="CHOPPA">{t('enums:career.CHOPPA')}</option>
-                  <option value="CHOSEN">{t('enums:career.CHOSEN')}</option>
-                  <option value="DISCIPLE_OF_KHAINE">
-                    {t('enums:career.DISCIPLE_OF_KHAINE')}
-                  </option>
-                  <option value="ENGINEER">{t('enums:career.ENGINEER')}</option>
-                  <option value="IRON_BREAKER">
-                    {t('enums:career.IRON_BREAKER')}
-                  </option>
-                  <option value="KNIGHT_OF_THE_BLAZING_SUN">
-                    {t('enums:career.KNIGHT_OF_THE_BLAZING_SUN')}
-                  </option>
-                  <option value="MAGUS">{t('enums:career.MAGUS')}</option>
-                  <option value="MARAUDER">{t('enums:career.MARAUDER')}</option>
-                  <option value="RUNE_PRIEST">
-                    {t('enums:career.RUNE_PRIEST')}
-                  </option>
-                  <option value="SHADOW_WARRIOR">
-                    {t('enums:career.SHADOW_WARRIOR')}
-                  </option>
-                  <option value="SHAMAN">{t('enums:career.SHAMAN')}</option>
-                  <option value="SLAYER">{t('enums:career.SLAYER')}</option>
-                  <option value="SORCERER">{t('enums:career.SORCERER')}</option>
-                  <option value="SQUIG_HERDER">
-                    {t('enums:career.SQUIG_HERDER')}
-                  </option>
-                  <option value="SWORD_MASTER">
-                    {t('enums:career.SWORD_MASTER')}
-                  </option>
-                  <option value="WARRIOR_PRIEST">
-                    {t('enums:career.WARRIOR_PRIEST')}
-                  </option>
-                  <option value="WHITE_LION">
-                    {t('enums:career.WHITE_LION')}
-                  </option>
-                  <option value="WITCH_ELF">
-                    {t('enums:career.WITCH_ELF')}
-                  </option>
-                  <option value="WITCH_HUNTER">
-                    {t('enums:career.WITCH_HUNTER')}
-                  </option>
-                  <option value="ZEALOT">{t('enums:career.ZEALOT')}</option>
-                </select>
-              </div>
-            </div>
+        </label>
+        <label htmlFor="stat">
+          <span>{t('pages:items.stat')}</span>
+          <div className="select">
+            <select
+              id="stat"
+              value={search.get('stat') ?? undefined}
+              onChange={(event) => {
+                search.set('stat', event.target.value);
+                setSearch(search);
+              }}
+            >
+              <option value="any">{t('pages:items.any')}</option>
+              <option value="WOUNDS">{t('enums:stat.WOUNDS')}</option>
+              <option value="WEAPON_SKILL">
+                {t('enums:stat.WEAPON_SKILL')}
+              </option>
+              <option value="WILLPOWER">{t('enums:stat.WILLPOWER')}</option>
+              <option value="BALLISTIC_SKILL">
+                {t('enums:stat.BALLISTIC_SKILL')}
+              </option>
+              <option value="TOUGHNESS">{t('enums:stat.TOUGHNESS')}</option>
+              <option value="INITIATIVE">{t('enums:stat.INITIATIVE')}</option>
+              <option value="STRENGTH">{t('enums:stat.STRENGTH')}</option>
+              <option value="INTELLIGENCE">
+                {t('enums:stat.INTELLIGENCE')}
+              </option>
+              <option value="BLOCK">{t('enums:stat.BLOCK')}</option>
+              <option value="PARRY">{t('enums:stat.PARRY')}</option>
+              <option value="DISRUPT">{t('enums:stat.DISRUPT')}</option>
+              <option value="EVADE">{t('enums:stat.EVADE')}</option>
+              <option value="ELEMENTAL_RESISTANCE">
+                {t('enums:stat.ELEMENTAL_RESISTANCE')}
+              </option>
+              <option value="SPIRIT_RESISTANCE">
+                {t('enums:stat.SPIRIT_RESISTANCE')}
+              </option>
+              <option value="CORPOREAL_RESISTANCE">
+                {t('enums:stat.CORPOREAL_RESISTANCE')}
+              </option>
+              <option value="HEAL_CRIT_RATE">
+                {t('enums:stat.HEAL_CRIT_RATE')}
+              </option>
+              <option value="RANGED_CRIT_RATE">
+                {t('enums:stat.RANGED_CRIT_RATE')}
+              </option>
+              <option value="MELEE_CRIT_RATE">
+                {t('enums:stat.MELEE_CRIT_RATE')}
+              </option>
+              <option value="MAGIC_CRIT_RATE">
+                {t('enums:stat.MAGIC_CRIT_RATE')}
+              </option>
+              <option value="ACTION_POINT_REGEN">
+                {t('enums:stat.ACTION_POINT_REGEN')}
+              </option>
+              <option value="MORALE_REGEN">
+                {t('enums:stat.MORALE_REGEN')}
+              </option>
+              <option value="HEALTH_REGEN">
+                {t('enums:stat.HEALTH_REGEN')}
+              </option>
+              <option value="CRITICAL_HIT_RATE_REDUCTION">
+                {t('enums:stat.CRITICAL_HIT_RATE_REDUCTION')}
+              </option>
+              <option value="BLOCK_STRIKETHROUGH">
+                {t('enums:stat.BLOCK_STRIKETHROUGH')}
+              </option>
+              <option value="PARRY_STRIKETHROUGH">
+                {t('enums:stat.PARRY_STRIKETHROUGH')}
+              </option>
+              <option value="DISRUPT_STRIKETHROUGH">
+                {t('enums:stat.DISRUPT_STRIKETHROUGH')}
+              </option>
+              <option value="EVADE_STRIKETHROUGH">
+                {t('enums:stat.EVADE_STRIKETHROUGH')}
+              </option>
+              <option value="HEALING_POWER">
+                {t('enums:stat.HEALING_POWER')}
+              </option>
+              <option value="MAGIC_POWER">{t('enums:stat.MAGIC_POWER')}</option>
+              <option value="RANGED_POWER">
+                {t('enums:stat.RANGED_POWER')}
+              </option>
+              <option value="MELEE_POWER">{t('enums:stat.MELEE_POWER')}</option>
+              <option value="FORTITUDE">{t('enums:stat.FORTITUDE')}</option>
+              <option value="AUTO_ATTACK_SPEED">
+                {t('enums:stat.AUTO_ATTACK_SPEED')}
+              </option>
+              <option value="AUTO_ATTACK_DAMAGE">
+                {t('enums:stat.AUTO_ATTACK_DAMAGE')}
+              </option>
+              <option value="ARMOR_PENETRATION">
+                {t('enums:stat.ARMOR_PENETRATION')}
+              </option>
+              <option value="ARMOR_PENETRATION_REDUCTION">
+                {t('enums:stat.ARMOR_PENETRATION_REDUCTION')}
+              </option>
+              <option value="HATE_CAUSED">{t('enums:stat.HATE_CAUSED')}</option>
+              <option value="HATE_RECEIVED">
+                {t('enums:stat.HATE_RECEIVED')}
+              </option>
+            </select>
           </div>
-        </div>
+        </label>
+        <label htmlFor="career">
+          <span>{t('pages:items.usableByCareer')}</span>
+          <div className="select">
+            <select
+              id="career"
+              value={search.get('career') ?? undefined}
+              onChange={(event) => {
+                search.set('career', event.target.value);
+                setSearch(search);
+              }}
+            >
+              <option value="all">{t('pages:items.all')}</option>
+              <option value="ARCHMAGE">{t('enums:career.ARCHMAGE')}</option>
+              <option value="BLACKGUARD">{t('enums:career.BLACKGUARD')}</option>
+              <option value="BLACK_ORC">{t('enums:career.BLACK_ORC')}</option>
+              <option value="BRIGHT_WIZARD">
+                {t('enums:career.BRIGHT_WIZARD')}
+              </option>
+              <option value="CHOPPA">{t('enums:career.CHOPPA')}</option>
+              <option value="CHOSEN">{t('enums:career.CHOSEN')}</option>
+              <option value="DISCIPLE_OF_KHAINE">
+                {t('enums:career.DISCIPLE_OF_KHAINE')}
+              </option>
+              <option value="ENGINEER">{t('enums:career.ENGINEER')}</option>
+              <option value="IRON_BREAKER">
+                {t('enums:career.IRON_BREAKER')}
+              </option>
+              <option value="KNIGHT_OF_THE_BLAZING_SUN">
+                {t('enums:career.KNIGHT_OF_THE_BLAZING_SUN')}
+              </option>
+              <option value="MAGUS">{t('enums:career.MAGUS')}</option>
+              <option value="MARAUDER">{t('enums:career.MARAUDER')}</option>
+              <option value="RUNE_PRIEST">
+                {t('enums:career.RUNE_PRIEST')}
+              </option>
+              <option value="SHADOW_WARRIOR">
+                {t('enums:career.SHADOW_WARRIOR')}
+              </option>
+              <option value="SHAMAN">{t('enums:career.SHAMAN')}</option>
+              <option value="SLAYER">{t('enums:career.SLAYER')}</option>
+              <option value="SORCERER">{t('enums:career.SORCERER')}</option>
+              <option value="SQUIG_HERDER">
+                {t('enums:career.SQUIG_HERDER')}
+              </option>
+              <option value="SWORD_MASTER">
+                {t('enums:career.SWORD_MASTER')}
+              </option>
+              <option value="WARRIOR_PRIEST">
+                {t('enums:career.WARRIOR_PRIEST')}
+              </option>
+              <option value="WHITE_LION">{t('enums:career.WHITE_LION')}</option>
+              <option value="WITCH_ELF">{t('enums:career.WITCH_ELF')}</option>
+              <option value="WITCH_HUNTER">
+                {t('enums:career.WITCH_HUNTER')}
+              </option>
+              <option value="ZEALOT">{t('enums:career.ZEALOT')}</option>
+            </select>
+          </div>
+        </label>
       </div>
       <div className="table-container">
         <table

--- a/src/pages/Kill.tsx
+++ b/src/pages/Kill.tsx
@@ -100,7 +100,7 @@ export const Kill = (): ReactElement => {
   const date = new Date(kill.time);
 
   return (
-    <div className="container is-max-desktop mt-2">
+    <div className="container is-max-widescreen mt-2">
       <nav className="breadcrumb" aria-label="breadcrumbs">
         <ul>
           <li>

--- a/src/pages/Quests.tsx
+++ b/src/pages/Quests.tsx
@@ -124,19 +124,17 @@ export const Quests = (): ReactElement => {
         </ul>
       </nav>
 
-      <div className="card mb-5">
-        <div className="card-content">
-          <div className="field">
-            <label className="label">{t('pages:quests.search')}</label>
-            <SearchBox
-              initialQuery={search.get('name') || ''}
-              onSubmit={(event) => {
-                search.set('name', event);
-                setSearch(search);
-              }}
-            />
-          </div>
-        </div>
+      <div className="filter-grid">
+        <label>
+          <span>{t('pages:quests.search')}</span>
+          <SearchBox
+            initialQuery={search.get('name') || ''}
+            onSubmit={(event) => {
+              search.set('name', event);
+              setSearch(search);
+            }}
+          />
+        </label>
       </div>
 
       <div className="table-container">

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -129,7 +129,7 @@ export const Search = (): ReactElement => {
   };
 
   return (
-    <div className="container is-max-desktop mt-2">
+    <div className="container is-max-widescreen mt-2">
       <nav className="breadcrumb" aria-label="breadcrumbs">
         <ul>
           <li>

--- a/src/pages/SearchGuild.tsx
+++ b/src/pages/SearchGuild.tsx
@@ -80,7 +80,7 @@ export const SearchGuild = (): ReactElement => {
   };
 
   return (
-    <div className="container is-max-desktop mt-2">
+    <div className="container is-max-widescreen mt-2">
       <nav className="breadcrumb" aria-label="breadcrumbs">
         <ul>
           <li>

--- a/src/style.scss
+++ b/src/style.scss
@@ -269,3 +269,56 @@ $tooltip-item-bonus: rgb(255, 255, 0);
   z-index: 5;
   pointer-events: none;
 }
+
+.filter-grid {
+  background: rgba(20, 20, 20, 0.55);
+  display: grid;
+  gap: 0.65rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  margin-bottom: 1.25rem;
+  padding: 0.75rem;
+}
+
+.filter-grid label > span {
+  display: block;
+  font-size: 0.72rem;
+  margin-bottom: 0.2rem;
+}
+
+.filter-grid .select {
+  height: auto;
+  width: 100%;
+}
+
+.filter-grid select,
+.filter-grid .control input.input {
+  background: rgba(20, 20, 20, 0.9);
+  border: 1px solid rgba(135, 123, 105, 0.4);
+  color: $text-strong;
+}
+
+.filter-grid select {
+  padding: 0.4rem;
+  width: 100%;
+}
+
+.filter-grid .field {
+  margin-bottom: 0 !important;
+}
+
+.filter-summary-bar {
+  align-items: center;
+  background: rgba(20, 20, 20, 0.45);
+  border-left: 3px solid rgba(135, 123, 105, 0.7);
+  display: flex;
+  font-size: 0.82rem;
+  justify-content: space-between;
+  margin-bottom: 1.25rem;
+  padding: 0.55rem 0.75rem;
+}
+
+@media (max-width: 520px) {
+  .filter-grid {
+    grid-template-columns: 1fr;
+  }
+}


### PR DESCRIPTION
## What

Adds a shared responsive main navigation and standardizes page containers, filter layouts, and common Bulma presentation across the killboard.

## Why

The previous work lived only in a cumulative fork branch. This version isolates the navigation and styling consistency changes directly onto upstream `main` so they can be reviewed without the scenario feature branch.

## Independence

No Cloudflare Worker, Emissary service, account credential, or external datastore is required.

## Checks

- `npm test` passes (TypeScript, Vite production build, and oxlint)
- `git diff --check` passes
- Existing non-fatal lint/Sass warnings remain

Opened as a draft for maintainer review of navigation labels and layout choices.
