### PR TITLE
Improve creature filters and vendor inventories

### DIFF
--- a/src/components/creature/VendorItems.tsx
+++ b/src/components/creature/VendorItems.tsx
@@ -1,23 +1,22 @@
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 import { gql } from '@apollo/client';
-import { useQuery } from '@apollo/client/react';
+import { useApolloClient } from '@apollo/client/react';
+import { useEffect, useState } from 'react';
 import type { Query } from '@/__generated__/graphql';
 import { ErrorMessage } from '@/components/global/ErrorMessage';
-import { QueryPagination } from '@/components/global/QueryPagination';
 import { GoldPrice } from '@/components/GoldPrice';
 
 const VENDOR_ITEMS = gql`
   query GetVendorItemsFromCreature(
     $creatureId: ID!
     $first: Int
-    $last: Int
-    $before: String
     $after: String
   ) {
     creature(id: $creatureId) {
       id
-      vendorItems(first: $first, last: $last, before: $before, after: $after) {
+      vendorItems(first: $first, after: $after) {
+        totalCount
         nodes {
           count
           item {
@@ -38,93 +37,228 @@ const VENDOR_ITEMS = gql`
         pageInfo {
           hasNextPage
           endCursor
-          hasPreviousPage
-          startCursor
         }
       }
     }
   }
 `;
 
+type VendorItemsConnectionType = NonNullable<Query['creature']>['vendorItems'];
+type VendorItemNode = NonNullable<
+  NonNullable<VendorItemsConnectionType>['nodes']
+>[number];
+
+// The API caps a single page at 50 items, and offers no server-side name
+// filter on a creature's vendor list. Some vendors sell 100-200+ items,
+// which used to mean clicking "Next" a dozen+ times to browse the whole
+// catalog. Instead we page through everything up front (a handful of
+// 50-item requests even for the biggest vendors) into local state, then
+// filter and scroll client-side.
 export const VendorItems = ({
   creatureId,
 }: {
   creatureId: string | undefined;
 }) => {
-  const perPage = 10;
+  const perPage = 50;
   const { t } = useTranslation(['common', 'components']);
-  const { loading, error, data, refetch } = useQuery<Query>(VENDOR_ITEMS, {
-    variables: {
-      creatureId,
-      first: perPage,
-    },
-  });
+  const client = useApolloClient();
+  const [search, setSearch] = useState('');
+  const [items, setItems] = useState<VendorItemNode[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<Error>();
+  const [hasDataIssue, setHasDataIssue] = useState(false);
 
-  if (loading) {
+  useEffect(() => {
+    let cancelled = false;
+    let totalCount: number | undefined;
+    const controller = new AbortController();
+
+    // Cursors from this API are just base64-encoded zero-based offsets
+    // (e.g. offset 49 -> btoa("49")), which lets us request an arbitrary
+    // [start, start + count) window directly instead of only being able to
+    // walk forward page by page.
+    const encodeOffset = (offset: number): string | undefined =>
+      offset > 0 ? btoa(String(offset - 1)) : undefined;
+
+    // Fetch a window of `count` items starting at `start`. If the window
+    // comes back null (one malformed row poisons the whole array under
+    // GraphQL's non-null propagation rules), split it in half and retry
+    // each half independently. This isolates the exact bad row(s) instead
+    // of discarding the entire 50-item page they happened to land on.
+    const fetchRange = async (
+      start: number,
+      count: number,
+    ): Promise<VendorItemNode[]> => {
+      if (count <= 0) {
+        return [];
+      }
+      const result = await client.query<Query>({
+        context: { fetchOptions: { signal: controller.signal } },
+        errorPolicy: 'all',
+        fetchPolicy: 'cache-first',
+        query: VENDOR_ITEMS,
+        variables: { after: encodeOffset(start), creatureId, first: count },
+      });
+      const connection = result.data?.creature?.vendorItems;
+      if (!connection) {
+        return [];
+      }
+      if (totalCount === undefined) {
+        totalCount = connection.totalCount;
+        if (!cancelled) {
+          setTotal(connection.totalCount);
+        }
+      }
+      if (connection.nodes) {
+        return connection.nodes;
+      }
+      if (count === 1) {
+        // Narrowed down to a single unrecoverable row.
+        if (!cancelled) {
+          setHasDataIssue(true);
+        }
+        return [];
+      }
+      const half = Math.ceil(count / 2);
+      const left = await fetchRange(start, half);
+      const right = await fetchRange(start + half, count - half);
+      return [...left, ...right];
+    };
+
+    const loadAll = async (): Promise<void> => {
+      setLoading(true);
+      setLoadError(undefined);
+      setHasDataIssue(false);
+      setItems([]);
+      let offset = 0;
+      const accumulated: VendorItemNode[] = [];
+
+      try {
+        do {
+          const nodes = await fetchRange(offset, perPage);
+          accumulated.push(...nodes);
+          offset += perPage;
+          if (!cancelled) {
+            setItems([...accumulated]);
+          }
+          if (totalCount === undefined || offset >= totalCount) {
+            break;
+          }
+        } while (!cancelled);
+      } catch (caughtError) {
+        if (!cancelled && !controller.signal.aborted) {
+          setLoadError(
+            caughtError instanceof Error
+              ? caughtError
+              : new Error('Unable to load vendor items.'),
+          );
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void loadAll();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [client, creatureId]);
+
+  if (loading && items.length === 0) {
     return <progress className="progress" />;
   }
-  if (error) {
-    return <ErrorMessage name={error.name} message={error.message} />;
+  if (loadError) {
+    return <ErrorMessage name={loadError.name} message={loadError.message} />;
   }
-
-  const vendorItems = data?.creature?.vendorItems;
-
-  if (vendorItems?.nodes == null) {
+  if (items.length === 0) {
     return <ErrorMessage customText={t('common:notFound')} />;
   }
 
-  if (vendorItems?.nodes == null) {
-    return null;
-  }
-
-  const { pageInfo } = vendorItems;
+  const filtered = search
+    ? items.filter((vendorItem) =>
+        vendorItem.item.name.toLowerCase().includes(search.toLowerCase()),
+      )
+    : items;
 
   return (
     <>
-      <table className="table is-striped is-fullwidth">
-        <thead>
-          <tr>
-            <th>{t('components:itemVendors.item')}</th>
-            <th>{t('components:itemVendors.price')}</th>
-          </tr>
-        </thead>
-        <tbody>
-          {vendorItems.nodes.map((vendorItem) => (
-            <tr key={vendorItem.item.id}>
-              <td>
-                <span className="icon-text">
-                  <figure className="image is-24x24 mx-1">
-                    <img src={vendorItem.item.iconUrl} alt="Item Icon" />
-                  </figure>
-                  <Link to={`/item/${vendorItem.item.id}`} className="mr-1">
-                    {vendorItem.item.name}
-                  </Link>
-                  x{vendorItem.count}
-                </span>
-              </td>
-              <td>
-                <GoldPrice price={vendorItem.price} />
-                {vendorItem.requiredItems.map((requiredItem) => (
-                  <span key={requiredItem.item.id} className="icon-text">
-                    <figure className="image is-24x24 mx-1">
-                      <img src={requiredItem.item.iconUrl} alt="Item Icon" />
-                    </figure>
-                    <Link to={`/item/${requiredItem.item.id}`} className="mr-1">
-                      {requiredItem.item.name}
-                    </Link>
-                    x{requiredItem.count}
-                  </span>
-                ))}
-              </td>
+      <div className="field">
+        <label>
+          <span>{t('components:itemVendors.filterItems')}</span>
+          <div className="control">
+            <input
+              className="input"
+              type="search"
+              placeholder={t('components:itemVendors.item')}
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+            />
+          </div>
+        </label>
+      </div>
+      {loading && (
+        <p className="mb-2">
+          Gathering {items.length} of {total || '…'} items…
+        </p>
+      )}
+      {hasDataIssue && (
+        <p className="mb-2 has-text-warning">
+          Some items could not be loaded due to a data issue and are missing
+          from this list.
+        </p>
+      )}
+      <div className="vendor-items-scroll-box">
+        <table className="table is-striped is-fullwidth">
+          <thead>
+            <tr>
+              <th>{t('components:itemVendors.item')}</th>
+              <th>{t('components:itemVendors.price')}</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
-      <QueryPagination
-        pageInfo={pageInfo}
-        refetch={refetch}
-        perPage={perPage}
-      />
+          </thead>
+          <tbody>
+            {filtered.map((vendorItem) => (
+              <tr key={vendorItem.item.id}>
+                <td>
+                  <span className="icon-text">
+                    <figure className="image is-24x24 mx-1">
+                      <img src={vendorItem.item.iconUrl} alt="Item Icon" />
+                    </figure>
+                    <Link to={`/item/${vendorItem.item.id}`} className="mr-1">
+                      {vendorItem.item.name}
+                    </Link>
+                    x{vendorItem.count}
+                  </span>
+                </td>
+                <td>
+                  <GoldPrice price={vendorItem.price} />
+                  {vendorItem.requiredItems.map((requiredItem) => (
+                    <span key={requiredItem.item.id} className="icon-text">
+                      <figure className="image is-24x24 mx-1">
+                        <img src={requiredItem.item.iconUrl} alt="Item Icon" />
+                      </figure>
+                      <Link
+                        to={`/item/${requiredItem.item.id}`}
+                        className="mr-1"
+                      >
+                        {requiredItem.item.name}
+                      </Link>
+                      x{requiredItem.count}
+                    </span>
+                  ))}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        {filtered.length === 0 && (
+          <p className="p-3">{t('common:noResults')}</p>
+        )}
+      </div>
     </>
   );
 };

--- a/src/i18n/en/components.json
+++ b/src/i18n/en/components.json
@@ -32,7 +32,8 @@
     "price": "Price",
     "zone": "Zone",
     "destruction": "Destruction",
-    "order": "Order"
+    "order": "Order",
+    "filterItems": "Filter items"
   },
   "itemQuests": {
     "questName": "Quest Name",

--- a/src/i18n/en/pages.json
+++ b/src/i18n/en/pages.json
@@ -112,9 +112,13 @@
   },
   "creatures": {
     "title": "Creatures",
+    "id": "ID",
     "search": "Name",
     "name": "Name",
-    "creatureSubType": "Type"
+    "creatureSubType": "Type",
+    "realm": "Realm",
+    "role": "Role",
+    "location": "Location"
   },
   "creature": {
     "creatureId": "Creature #{{creatureId}}",

--- a/src/pages/Creatures.tsx
+++ b/src/pages/Creatures.tsx
@@ -3,12 +3,17 @@ import { useTranslation } from 'react-i18next';
 import { gql } from '@apollo/client';
 import { useQuery } from '@apollo/client/react';
 import useWindowDimensions from '@/hooks/useWindowDimensions';
-import type { CreatureFilterInput, Query } from '@/__generated__/graphql';
+import {
+  Realm,
+  type CreatureFilterInput,
+  type Query,
+} from '@/__generated__/graphql';
 import { ErrorMessage } from '@/components/global/ErrorMessage';
 import { SearchBox } from '@/components/global/SearchBox';
 import { QueryPagination } from '@/components/global/QueryPagination';
 import type { ReactElement } from 'react';
 import clsx from 'clsx';
+import { creatureTitleIcon, creatureTitleLabel } from '../utils';
 
 const CREATURES = gql`
   query GetCreatures(
@@ -29,6 +34,13 @@ const CREATURES = gql`
         id
         name
         realm
+        title
+        spawns {
+          zone {
+            id
+            name
+          }
+        }
       }
       pageInfo {
         hasNextPage
@@ -121,17 +133,85 @@ export const Creatures = (): ReactElement => {
         >
           <thead>
             <tr>
+              <th>{t('pages:creatures.id')}</th>
               <th>{t('pages:creatures.name')}</th>
+              <th>{t('pages:creatures.realm')}</th>
+              <th>{t('pages:creatures.role')}</th>
+              <th>{t('pages:creatures.location')}</th>
             </tr>
           </thead>
           <tbody>
-            {entries.map((creature) => (
-              <tr key={creature.id}>
-                <td>
-                  <Link to={`/creature/${creature.id}`}>{creature.name}</Link>
-                </td>
-              </tr>
-            ))}
+            {entries.map((creature) => {
+              const zoneNames = [
+                ...new Set(
+                  creature.spawns
+                    .map((spawn) => spawn.zone?.name)
+                    .filter((name): name is string => Boolean(name)),
+                ),
+              ];
+              const icon = creatureTitleIcon(creature.title);
+              const label = creatureTitleLabel(creature.title);
+
+              return (
+                <tr key={creature.id}>
+                  <td>{creature.id}</td>
+                  <td>
+                    <Link to={`/creature/${creature.id}`}>{creature.name}</Link>
+                  </td>
+                  <td>
+                    {creature.realm === Realm.Order && (
+                      <span className="icon-text">
+                        <figure className="image is-24x24 m-0 mr-1">
+                          <img
+                            src="/images/icons/scenario/order.png"
+                            width={24}
+                            height={24}
+                            alt={t('common:realmOrder')}
+                          />
+                        </figure>
+                        {t('common:realmOrder')}
+                      </span>
+                    )}
+                    {creature.realm === Realm.Destruction && (
+                      <span className="icon-text">
+                        <figure className="image is-24x24 m-0 mr-1">
+                          <img
+                            src="/images/icons/scenario/destruction.png"
+                            width={24}
+                            height={24}
+                            alt={t('common:realmDestruction')}
+                          />
+                        </figure>
+                        {t('common:realmDestruction')}
+                      </span>
+                    )}
+                    {creature.realm == null && (
+                      <span>{t('common:realmNeutral')}</span>
+                    )}
+                  </td>
+                  <td>
+                    {label && (
+                      <span className="icon-text">
+                        {icon && (
+                          <figure className="image is-24x24 m-0 mr-1">
+                            <img src={icon} width={24} height={24} alt="" />
+                          </figure>
+                        )}
+                        {label}
+                      </span>
+                    )}
+                  </td>
+                  <td>
+                    {zoneNames.length > 0 && (
+                      <span>
+                        {zoneNames[0]}
+                        {zoneNames.length > 1 && ` (+${zoneNames.length - 1})`}
+                      </span>
+                    )}
+                  </td>
+                </tr>
+              );
+            })}
           </tbody>
         </table>
       </div>

--- a/src/style.scss
+++ b/src/style.scss
@@ -269,3 +269,22 @@ $tooltip-item-bonus: rgb(255, 255, 0);
   z-index: 5;
   pointer-events: none;
 }
+
+.vendor-items-scroll-box {
+  background: rgba(20, 20, 20, 0.45);
+  border: 1px solid rgba(135, 123, 105, 0.35);
+  border-radius: 4px;
+  max-height: 480px;
+  overflow-y: auto;
+}
+
+.vendor-items-scroll-box table {
+  margin-bottom: 0;
+}
+
+.vendor-items-scroll-box thead th {
+  background: #1a1a1a;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -4,6 +4,7 @@ import {
   KillDamageSourceType,
   QuestRepeatableType
 } from '@/__generated__/graphql';
+import { CreatureTitle } from '@/__generated__/schema-types';
 
 export const careerIcon = (career: Career): string => {
   switch (career) {
@@ -195,4 +196,30 @@ export const questTypeIcon = (
   }
 
   return 'quest_green.png';
+};
+
+export const creatureTitleIcon = (title: CreatureTitle): string | null => {
+  const value = title as string;
+  if (title === CreatureTitle.None) return null;
+  if (value.includes('HEAL') || value.includes('RITUALIST')) return '/images/icons/healing.png';
+  if (value === 'BLACKSMITH') return '/images/corner_icons/ea_icon_corner_blacksmith.png';
+  if (value.includes('MERCHANT') || value.includes('VENDOR') || value.includes('QUARTERMASTER')) return '/images/corner_icons/ea_icon_corner_merchant.png';
+  if (value.includes('TRAINER')) return '/images/corner_icons/ea_icon_corner_training.png';
+  if (value === 'APOTHECARY') return '/images/corner_icons/ea_icon_corner_apothecary.png';
+  if (value === 'AUCTIONEER') return '/images/corner_icons/ea_icon_corner_auction.png';
+  if (value === 'CULTIVATOR') return '/images/corner_icons/ea_icon_corner_cultivating.png';
+  if (value.includes('REGISTRAR') || value === 'HERALD') return '/images/corner_icons/ea_icon_corner_guild.png';
+  if (value === 'POSTMASTER') return '/images/corner_icons/ea_icon_corner_mail.png';
+  if (value === 'BANKER' || value.includes('VAULT')) return '/images/corner_icons/ea_icon_corner_bag.png';
+  if (value.includes('GUARD') || value.includes('LORD') || value.includes('GENERAL') || value === 'DOGOF_WAR' || value === 'SERGEANT') return '/images/corner_icons/ea_icon_corner_rvr.png';
+  return null;
+};
+
+export const creatureTitleLabel = (title: CreatureTitle): string => {
+  if (title === CreatureTitle.None) return '';
+  return (title as string)
+    .split('_')
+    .flatMap((word) => word.length > 2 && word.endsWith('OF') ? [word.slice(0, -2), 'OF'] : [word])
+    .map((word) => word.charAt(0) + word.slice(1).toLowerCase())
+    .join(' ');
 };


### PR DESCRIPTION
## What

Improves creature browsing and vendor inventories with API-backed creature filters, readable creature titles/icons, complete vendor inventory loading, item search, and a scrollable table.

## Why

Large vendor inventories previously required many pagination clicks and malformed rows could hide an entire page. The new loader uses the existing GraphQL connection, isolates bad rows, and lets users filter the loaded inventory locally.

## Independence

This branch is based directly on upstream `main` and uses only the existing killboard GraphQL API. It has no Cloudflare Worker, D1, Emissary service, or account dependency.

## Checks

- TypeScript and Vite production build pass
- `git diff --check` passes
- Oxlint reports existing repository errors/warnings plus non-fatal style warnings in the new code

Opened as a draft so the API request pattern and handling of malformed vendor rows can be reviewed.
