### PR TITLE
Add live event calendar

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import { Storyline } from '@/pages/Storyline';
 import { StorylineEntry } from '@/pages/StorylineEntry';
 import { StorylineActivity } from '@/pages/StorylineActivity';
 import { InstanceStatistics } from '@/pages/InstanceStatistics';
+import { Events } from '@/pages/Events';
 
 // Extend the Window interface to include gtag
 declare global {
@@ -58,6 +59,7 @@ const App = () => {
       <Route path="/" element={<Home tab="players" />} />
       <Route path="/guilds" element={<Home tab="guilds" />} />
       <Route path="/scenarios" element={<Home tab="scenarios" />} />
+      <Route path="/events" element={<Events />} />
       <Route path="/kill/:id" element={<Kill />} />
       <Route path="/kills" element={<Kills />} />
       <Route path="/character/:id" element={<Character tab="kills" />} />

--- a/src/i18n/en/common.json
+++ b/src/i18n/en/common.json
@@ -17,6 +17,7 @@
   "details": "Details",
   "storylines": "Storylines",
   "instances": "Instances",
+  "events": "Events",
   "scenarios": "Scenarios",
   "tier": "Tier",
   "noResults": "No results found"

--- a/src/i18n/en/pages.json
+++ b/src/i18n/en/pages.json
@@ -1,4 +1,8 @@
 {
+  "events": {
+    "title": "Live Events",
+    "description": "Active and upcoming Return of Reckoning events."
+  },
   "characterPage": {
     "characterId": "Character #{{characterId}}",
     "kills": "Kills",

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -1,0 +1,201 @@
+import { gql } from '@apollo/client';
+import { useQuery } from '@apollo/client/react';
+import { type ReactElement, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Link } from 'react-router';
+import { ErrorMessage } from '@/components/global/ErrorMessage';
+
+const QUERY = gql`
+  query GetEvents {
+    events {
+      eventType: __typename
+      name
+      startTime
+      endTime
+    }
+  }
+`;
+
+interface EventEntry {
+  eventType: string;
+  name: string;
+  startTime: string;
+  endTime: string | null;
+}
+
+interface EventQueryData {
+  events: EventEntry[];
+}
+
+const SERVER_TIME_ZONE = 'Europe/Zurich';
+
+const localDateTime = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+const serverDateTime = new Intl.DateTimeFormat('en-GB', {
+  timeZone: SERVER_TIME_ZONE,
+  day: 'numeric',
+  month: 'short',
+  year: 'numeric',
+  hour: '2-digit',
+  minute: '2-digit',
+  timeZoneName: 'short',
+});
+
+const eventType = (typeName?: string): string => {
+  switch (typeName) {
+    case 'CitySiegeEvent': {
+      return 'City Siege';
+    }
+    case 'ZandriExpeditionEvent': {
+      return 'Expedition';
+    }
+    default: {
+      return 'Live Event';
+    }
+  }
+};
+
+const durationLabel = (milliseconds: number): string => {
+  const totalMinutes = Math.max(0, Math.floor(milliseconds / 60_000));
+  const minutesPerDay = 24 * 60;
+  const days = Math.floor(totalMinutes / minutesPerDay);
+  const hours = Math.floor((totalMinutes % minutesPerDay) / 60);
+  const minutes = totalMinutes % 60;
+  return `${days > 0 ? `${days}d ` : ''}${hours > 0 ? `${hours}h ` : ''}${minutes}m`;
+};
+
+const EventCard = ({
+  event,
+  now,
+}: {
+  event: EventEntry;
+  now: number;
+}): ReactElement => {
+  const start = new Date(event.startTime).getTime();
+  const end = event.endTime == null ? null : new Date(event.endTime).getTime();
+  const active = start <= now && (end == null || end > now);
+  const target = now < start ? start : end;
+
+  return (
+    <article className={`event-card${active ? ' event-card-active' : ''}`}>
+      <header className="event-card-header">
+        <span className="event-card-type">{eventType(event.eventType)}</span>
+        <span className="tag is-dark">
+          {active ? 'Active now' : 'Upcoming'}
+        </span>
+      </header>
+      <h2 className="title is-5 mt-3 mb-3">
+        {event.name ?? eventType(event.eventType)}
+      </h2>
+      <dl className="event-times">
+        <div>
+          <dt>Starts</dt>
+          <dd>
+            <span>
+              <strong>Local</strong> {localDateTime.format(start)}
+            </span>
+            <span>
+              <strong>Server</strong> {serverDateTime.format(start)}
+            </span>
+          </dd>
+        </div>
+        {end != null && (
+          <div>
+            <dt>Ends</dt>
+            <dd>
+              <span>
+                <strong>Local</strong> {localDateTime.format(end)}
+              </span>
+              <span>
+                <strong>Server</strong> {serverDateTime.format(end)}
+              </span>
+            </dd>
+          </div>
+        )}
+      </dl>
+      {target != null && (
+        <p className="event-countdown">
+          {now < start ? 'Starts' : 'Ends'} in {durationLabel(target - now)}
+        </p>
+      )}
+    </article>
+  );
+};
+
+export const Events = (): ReactElement => {
+  const { t } = useTranslation(['common', 'pages']);
+  const { loading, error, data } = useQuery<EventQueryData>(QUERY);
+  const [now, setNow] = useState(Date.now());
+
+  useEffect(() => {
+    const timer = globalThis.setInterval(() => setNow(Date.now()), 30_000);
+    return () => globalThis.clearInterval(timer);
+  }, []);
+
+  const events = useMemo(
+    () =>
+      [...(data?.events ?? [])]
+        .filter(
+          (event) =>
+            event.endTime == null || new Date(event.endTime).getTime() > now,
+        )
+        .sort((left, right) => {
+          const leftStart = new Date(left.startTime).getTime();
+          const rightStart = new Date(right.startTime).getTime();
+          const leftActive =
+            leftStart <= now &&
+            (left.endTime == null || new Date(left.endTime).getTime() > now);
+          const rightActive =
+            rightStart <= now &&
+            (right.endTime == null || new Date(right.endTime).getTime() > now);
+          return (
+            Number(rightActive) - Number(leftActive) || leftStart - rightStart
+          );
+        }),
+    [data?.events, now],
+  );
+
+  if (loading) {
+    return <progress className="progress" />;
+  }
+  if (error) {
+    return <ErrorMessage name={error.name} message={error.message} />;
+  }
+
+  return (
+    <div className="container is-max-widescreen mt-2">
+      <nav className="breadcrumb" aria-label="breadcrumbs">
+        <ul>
+          <li>
+            <Link to="/">{t('common:home')}</Link>
+          </li>
+          <li className="is-active">
+            <Link to="/events">{t('common:events')}</Link>
+          </li>
+        </ul>
+      </nav>
+      <header className="has-text-centered mb-5">
+        <h1 className="title">{t('pages:events.title')}</h1>
+        <p className="subtitle is-6">{t('pages:events.description')}</p>
+      </header>
+      {events.length === 0 ? (
+        <div className="notification is-dark">
+          No active or upcoming events were returned.
+        </div>
+      ) : (
+        <section className="event-grid" aria-label="Active and upcoming events">
+          {events.map((event) => (
+            <EventCard
+              key={`${event.eventType}-${event.name}-${event.startTime}`}
+              event={event}
+              now={now}
+            />
+          ))}
+        </section>
+      )}
+    </div>
+  );
+};

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -34,6 +34,14 @@ const localDateTime = new Intl.DateTimeFormat(undefined, {
   timeStyle: 'short',
 });
 
+const localTimeZone = new Intl.DateTimeFormat(undefined, {
+  timeZoneName: 'short',
+})
+  .formatToParts(new Date())
+  .find((part) => part.type === 'timeZoneName')?.value;
+
+const localTimeLabel = localTimeZone ? `Local (${localTimeZone})` : 'Local';
+
 const serverDateTime = new Intl.DateTimeFormat('en-GB', {
   timeZone: SERVER_TIME_ZONE,
   day: 'numeric',
@@ -41,8 +49,15 @@ const serverDateTime = new Intl.DateTimeFormat('en-GB', {
   year: 'numeric',
   hour: '2-digit',
   minute: '2-digit',
-  timeZoneName: 'short',
 });
+
+const serverTimeZone = (time: number): string | undefined =>
+  new Intl.DateTimeFormat('en-GB', {
+    timeZone: SERVER_TIME_ZONE,
+    timeZoneName: 'short',
+  })
+    .formatToParts(time)
+    .find((part) => part.type === 'timeZoneName')?.value;
 
 const eventType = (typeName?: string): string => {
   switch (typeName) {
@@ -95,10 +110,11 @@ const EventCard = ({
           <dt>Starts</dt>
           <dd>
             <span>
-              <strong>Local</strong> {localDateTime.format(start)}
+              <strong>{localTimeLabel}</strong> {localDateTime.format(start)}
             </span>
             <span>
-              <strong>Server</strong> {serverDateTime.format(start)}
+              <strong>Server ({serverTimeZone(start)})</strong>{' '}
+              {serverDateTime.format(start)}
             </span>
           </dd>
         </div>
@@ -107,10 +123,11 @@ const EventCard = ({
             <dt>Ends</dt>
             <dd>
               <span>
-                <strong>Local</strong> {localDateTime.format(end)}
+                <strong>{localTimeLabel}</strong> {localDateTime.format(end)}
               </span>
               <span>
-                <strong>Server</strong> {serverDateTime.format(end)}
+                <strong>Server ({serverTimeZone(end)})</strong>{' '}
+                {serverDateTime.format(end)}
               </span>
             </dd>
           </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -35,6 +35,9 @@ export const Home = ({
         <li className={clsx({ 'is-active': tab === 'skirmishes' })}>
           <Link to="/skirmishes">{t('pages:home.showSkirmishes')}</Link>
         </li>
+        <li>
+          <Link to="/events">{t('common:events')}</Link>
+        </li>
       </div>
       {tab === 'scenarios' && (
         <>

--- a/src/style.scss
+++ b/src/style.scss
@@ -156,6 +156,76 @@ $tooltip-item-set-enabled: rgb(0, 255, 0);
 $tooltip-item-set-disabled: rgb(175, 175, 175);
 $tooltip-item-bonus: rgb(255, 255, 0);
 
+.event-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 280px), 1fr));
+  gap: 1rem;
+  padding-bottom: 2rem;
+}
+
+.event-card {
+  background: rgba(10, 21, 38, 0.85);
+  border: 1px solid #38445e;
+  border-radius: 0.5rem;
+  padding: 1.1rem;
+}
+
+.event-card-active {
+  border-color: #3d9361;
+  box-shadow: inset 3px 0 #55c983;
+}
+
+.event-card-header {
+  align-items: center;
+  display: flex;
+  gap: 0.5rem;
+  justify-content: space-between;
+}
+
+.event-card-type {
+  color: #9ba5ba;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.event-times {
+  margin: 0;
+}
+
+.event-times > div {
+  display: grid;
+  gap: 0.5rem;
+  grid-template-columns: 3.5rem 1fr;
+  margin: 0.65rem 0;
+}
+
+.event-times dt,
+.event-times dd strong {
+  color: #7f8ba2;
+  font-size: 0.75rem;
+}
+
+.event-times dd {
+  display: grid;
+  gap: 0.3rem;
+  margin: 0;
+}
+
+.event-times dd span {
+  display: grid;
+  gap: 0.35rem;
+  grid-template-columns: 3.6rem 1fr;
+}
+
+.event-countdown {
+  border-top: 1px solid #2d374b;
+  color: #c4cede;
+  font-weight: 600;
+  margin-top: 1rem;
+  padding-top: 0.8rem;
+}
+
 .item-name-utility {
   color: $rarity-utility;
 }


### PR DESCRIPTION
## What

- adds an `/events` page for active and upcoming live events, city sieges, and Zandri expeditions
- shows start/end times in both the visitor's local timezone and Server Time (CET/CEST via `Europe/Zurich`)
- adds active/upcoming states and automatically updating start/end countdowns
- links the calendar from the main killboard tabs and provides a responsive card layout

## Why

The production API already exposes event scheduling data, but players currently have no killboard view that turns it into a convenient calendar.

## API note

The query intentionally omits event IDs. At present, requesting `id` on a `LiveEvent` produces an `HC0053` resolver cast error that can null the `events` response. The stable fields used here are `__typename`, `name`, `startTime`, and `endTime`.

## Validation

- `npm test`
- Prettier check for all changed source files
- focused type-aware lint of `src/pages/Events.tsx`

Existing dependency audit, Sass deprecation, bundle-size, and unrelated lint warnings remain unchanged.
